### PR TITLE
Silence gcc warning "./generic/tkImgSVG.c:426:2: warning: enumeration…

### DIFF
--- a/generic/tkImgSVG.c
+++ b/generic/tkImgSVG.c
@@ -436,8 +436,7 @@ ParseSVGWithOptions(
 	    }
 	    parameterScaleSeen = 1;
 		break;
-	case OPT_DPI:
-		/* no option restriction so always pass */
+	default:
 		break;
 	}
 

--- a/generic/tkImgSVG.c
+++ b/generic/tkImgSVG.c
@@ -435,6 +435,10 @@ ParseSVGWithOptions(
 		goto error;
 	    }
 	    parameterScaleSeen = 1;
+		break;
+	case OPT_DPI:
+		/* no option restriction so always pass */
+		break;
 	}
 
 	/*


### PR DESCRIPTION
… value ‘OPT_DPI’ not handled in switch [-Wswitch]" by defining all cases.